### PR TITLE
Validate tech-radar.json with typed models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,9 +83,3 @@ repos:
         entry: uv run --locked prek validate-config .pre-commit-config.yaml
         language: system
         pass_filenames: false
-      - id: cosmic-ray
-        name: cosmic-ray baseline
-        entry: uv run --locked cosmic-ray init
-        language: system
-        pass_filenames: false
-        stages: [manual]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Use `make` to run common development tasks:
 - `make lint`: Run Ruff checks for Python linting.
 - `make typecheck`: Run `ty` for type checking.
 - `make test`: Run `pytest` with coverage requirements.
+- `make mutation-test`: Run mutation testing with `cosmic-ray`.
 - `make prek`: Run all configured pre-commit and pre-push hooks over all files.
 - `make check`: Run the full verification suite (lint, typecheck, tests, docs, audit).
 - `make serve-docs`: Serve the documentation site locally.
@@ -52,3 +53,8 @@ Use `make` to run common development tasks:
 2. **Verify changes**: Run `make check` to ensure your changes meet the project's quality standards.
 3. **Type Safety**: We use `ty` for type checking. Ensure all new code is properly typed.
 4. **Testing**: All new features and bug fixes must be accompanied by tests. We aim for 100% coverage.
+5. **Mutation Testing**: We use `cosmic-ray` for mutation testing. Per the [Definition of Done](docs/definition-of-done.md) and [ADR 0009](docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md), you must run mutation testing for your changes and ensure no mutants survive without justification.
+
+    ```bash
+    make mutation-test
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,10 @@ Use `make` to run common development tasks:
 2. **Verify changes**: Run `make check` to ensure your changes meet the project's quality standards.
 3. **Type Safety**: We use `ty` for type checking. Ensure all new code is properly typed.
 4. **Testing**: All new features and bug fixes must be accompanied by tests. We aim for 100% coverage.
-5. **Mutation Testing**: We use `cosmic-ray` for mutation testing. Per the [Definition of Done](docs/definition-of-done.md) and [ADR 0009](docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md), you must run mutation testing for your changes and ensure no mutants survive without justification.
+5. **Mutation Testing**: We use `cosmic-ray` for mutation testing. Per the
+   [Definition of Done](docs/definition-of-done.md) and
+   [ADR 0009](docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md), you must run mutation testing
+   for your changes and ensure no mutants survive without justification.
 
     ```bash
     make mutation-test

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 		'  make markdown-lint Run Markdown lint checks with rumdl' \
 		'  make typecheck   Run ty type checking' \
 		'  make test        Run pytest with coverage gates' \
+		'  make mutation-test Run mutation testing with cosmic-ray' \
 		'  make docs        Build the docs site in strict mode' \
 		'  make serve-docs  Serve the docs site locally' \
 		'  make audit       Run pip-audit against the locked environment' \
@@ -37,6 +38,11 @@ typecheck:
 
 test:
 	uv run --locked pytest
+
+mutation-test:
+	uv run --locked cosmic-ray init cosmic-ray.toml cosmic-ray.sqlite
+	uv run --locked cosmic-ray run cosmic-ray.toml cosmic-ray.sqlite
+	uv run --locked cosmic-ray summary cosmic-ray.sqlite
 
 docs:
 	uv run --locked mkdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,7 @@ test:
 	uv run --locked pytest
 
 mutation-test:
-	uv run --locked cosmic-ray init cosmic-ray.toml cosmic-ray.sqlite
-	uv run --locked cosmic-ray run cosmic-ray.toml cosmic-ray.sqlite
-	uv run --locked cosmic-ray summary cosmic-ray.sqlite
+	uv run --locked python scripts/mutation_test.py --base origin/main
 
 docs:
 	uv run --locked mkdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lock sync fmt lint markdown-lint typecheck test docs serve-docs audit prek check
+.PHONY: help lock sync fmt lint markdown-lint typecheck test mutation-test docs serve-docs audit prek check
 
 help:
 	@printf '%s\n' \

--- a/docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md
+++ b/docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md
@@ -1,0 +1,29 @@
+# ADR 0009: Use Cosmic Ray for mutation testing
+
+## Status
+
+Accepted
+
+## Context
+
+We have a strict quality policy, including 100% branch coverage for Python code.
+However, high coverage does not guarantee that tests are effective at catching
+regressions or that the assertions are meaningful. Mutation testing provides a
+way to verify the quality of the tests themselves by introducing small changes
+(mutations) to the source code and ensuring that at least one test fails.
+
+## Decision
+
+We will use `cosmic-ray` for mutation testing of the Python radar toolchain.
+
+Mutation testing will be part of the "Definition of Done" for any pull request
+affecting Python source code.
+
+## Consequences
+
+- Developers must run `cosmic-ray` for their changes.
+- Surviving mutants must be addressed by improving tests or explicitly
+  justified if they represent unreachable or irrelevant code.
+- Mutation testing can be slow, so it is recommended to run it on a scoped
+  basis (e.g., against specific modules) during development.
+- `cosmic-ray` configuration is maintained in `pyproject.toml`.

--- a/docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md
+++ b/docs/adrs/0009-use-cosmic-ray-for-mutation-testing.md
@@ -26,4 +26,7 @@ affecting Python source code.
   justified if they represent unreachable or irrelevant code.
 - Mutation testing can be slow, so it is recommended to run it on a scoped
   basis (e.g., against specific modules) during development.
-- `cosmic-ray` configuration is maintained in `pyproject.toml`.
+- `cosmic-ray` runs are configured via a transient TOML file generated for
+  each run by the mutation test helper script, which can scope the target
+  module and set execution options such as the test command, timeout, and
+  distributor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ The governing documents live here:
 - [ADR 0006: Thin Makefile command surface](adrs/0006-thin-makefile-command-surface.md)
 - [ADR 0007: Use prek as the hook runner](adrs/0007-use-prek-as-hook-runner.md)
 - [ADR 0008: Use Astral ty for type checking](adrs/0008-use-astral-ty-for-type-checking.md)
+- [ADR 0009: Use Cosmic Ray for mutation testing](adrs/0009-use-cosmic-ray-for-mutation-testing.md)
 - [Phase 00 design](designs/phase-00-foundation.md)
 
 The current delivery strategy is:

--- a/scripts/mutation_test.py
+++ b/scripts/mutation_test.py
@@ -43,6 +43,14 @@ def file_to_module(file_path):
     return ".".join(module_parts)
 
 
+def file_to_module_path(file_path):
+    """Convert a changed file path to a valid cosmic-ray module-path target."""
+    path = Path(file_path)
+    if path.name == "__init__.py":
+        return str(path.parent)
+    return str(path)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run scoped mutation testing")
     parser.add_argument(
@@ -58,6 +66,7 @@ def main():
         sys.exit(0)
 
     modules = [file_to_module(f) for f in changed_files]
+    module_paths = [file_to_module_path(f) for f in changed_files]
     print(f"Changed modules: {', '.join(modules)}")
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -75,13 +84,12 @@ timeout = 10.0
 [cosmic-ray.distributor]
 name = "local"
 """
-        for module in modules:
+        for module, module_path in zip(modules, module_paths, strict=True):
             print(f"\n--- Testing module: {module} ---")
 
-            module_file = f"src/{module.replace('.', '/')}.py"
             scoped_config = base_config.replace(
                 'module-path = "src/sett_and_hive_radar"',
-                f'module-path = "{module_file}"',
+                f'module-path = "{module_path}"',
             )
             config_path.write_text(scoped_config)
 

--- a/scripts/mutation_test.py
+++ b/scripts/mutation_test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run_command(cmd, check=True):
+    print(f"Running: {' '.join(cmd)}")
+    return subprocess.run(cmd, check=check, capture_output=True, text=True)
+
+
+def get_changed_python_files(base_branch="origin/main"):
+    """Get list of changed .py files in src/ compared to base_branch."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", base_branch, "--name-only", "--", "src/**/*.py"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        print(f"Error: Could not get diff from {base_branch}")
+        return []
+    else:
+        return [f for f in result.stdout.splitlines() if f.endswith(".py")]
+
+
+def file_to_module(file_path):
+    """Convert a file path to a python module path."""
+    p = Path(file_path)
+    parts = p.parts[1:] if p.parts[0] == "src" else p.parts
+
+    module_parts = list(parts[:-1])
+    stem = p.stem
+    if stem != "__init__":
+        module_parts.append(stem)
+
+    return ".".join(module_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run scoped mutation testing")
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base branch for diff (default: origin/main)",
+    )
+    args = parser.parse_args()
+
+    changed_files = get_changed_python_files(args.base)
+    if not changed_files:
+        print("No changed Python files found in src/.")
+        sys.exit(0)
+
+    modules = [file_to_module(f) for f in changed_files]
+    print(f"Changed modules: {', '.join(modules)}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        config_path = tmp_path / "cosmic-ray.toml"
+        session_path = tmp_path / "session.sqlite"
+
+        base_config = """
+[cosmic-ray]
+module-path = "src/sett_and_hive_radar"
+python-version = "3.14"
+test-command = "pytest"
+timeout = 10.0
+
+[cosmic-ray.distributor]
+name = "local"
+"""
+        for module in modules:
+            print(f"\n--- Testing module: {module} ---")
+
+            module_file = f"src/{module.replace('.', '/')}.py"
+            scoped_config = base_config.replace(
+                'module-path = "src/sett_and_hive_radar"',
+                f'module-path = "{module_file}"',
+            )
+            config_path.write_text(scoped_config)
+
+            try:
+                run_command(
+                    [
+                        "uv",
+                        "run",
+                        "cosmic-ray",
+                        "init",
+                        "--force",
+                        str(config_path),
+                        str(session_path),
+                    ]
+                )
+                run_command(
+                    ["uv", "run", "cosmic-ray", "exec", str(config_path), str(session_path)]
+                )
+
+                dump_result = run_command(["uv", "run", "cosmic-ray", "dump", str(session_path)])
+
+                survivors = 0
+                for line in dump_result.stdout.splitlines():
+                    if not line.strip():
+                        continue
+                    data = json.loads(line)
+                    if (
+                        isinstance(data, list)
+                        and len(data) > 1
+                        and data[1].get("test_outcome") == "survived"
+                    ):
+                        survivors += 1
+                        print(f"MUTANT SURVIVED: {data[1].get('diff')}")
+
+                if survivors > 0:
+                    print(f"FAILURE: {survivors} mutants survived in {module}")
+                    sys.exit(1)
+                else:
+                    print(f"SUCCESS: All mutants killed in {module}")
+
+            except subprocess.CalledProcessError as e:
+                print(f"Error during cosmic-ray execution for {module}:")
+                print(e.stderr)
+                sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mutation_test.py
+++ b/scripts/mutation_test.py
@@ -21,9 +21,11 @@ def get_changed_python_files(base_branch="origin/main"):
             capture_output=True,
             text=True,
         )
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
         print(f"Error: Could not get diff from {base_branch}")
-        return []
+        if e.stderr:
+            print(e.stderr)
+        raise
     else:
         return [f for f in result.stdout.splitlines() if f.endswith(".py")]
 

--- a/src/sett_and_hive_radar/models.py
+++ b/src/sett_and_hive_radar/models.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, Field, model_validator
+
+
+class Blip(BaseModel):
+    name: str
+    quadrant: str
+    ring: str
+    is_new: bool = Field(alias="isNew", default=False)
+    description: str
+
+
+class Radar(BaseModel):
+    title: str
+    quadrants: list[str]
+    rings: list[str]
+    blips: list[Blip]
+
+    @model_validator(mode="after")
+    def validate_blips_match_radar(self) -> Radar:
+        quadrants_set = set(self.quadrants)
+        rings_set = set(self.rings)
+
+        for i, blip in enumerate(self.blips):
+            if blip.quadrant not in quadrants_set:
+                msg = (
+                    f"Blip {i} ('{blip.name}') has invalid quadrant '{blip.quadrant}'. "
+                    f"Must be one of: {self.quadrants}"
+                )
+                raise ValueError(msg)
+            if blip.ring not in rings_set:
+                msg = (
+                    f"Blip {i} ('{blip.name}') has invalid ring '{blip.ring}'. "
+                    f"Must be one of: {self.rings}"
+                )
+                raise ValueError(msg)
+        return self

--- a/src/sett_and_hive_radar/models.py
+++ b/src/sett_and_hive_radar/models.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class Blip(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     quadrant: str
     ring: str
@@ -10,6 +12,8 @@ class Blip(BaseModel):
 
 
 class Radar(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     title: str
     quadrants: list[str]
     rings: list[str]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,10 @@
+import json
+
 import pytest
 from pydantic import ValidationError
 
-from sett_and_hive_radar.models import Radar
+from sett_and_hive_radar.models import Blip, Radar
+from sett_and_hive_radar.paths import project_root
 
 
 def test_valid_radar():
@@ -18,6 +21,12 @@ def test_valid_radar():
     assert len(radar.blips) == 1
     assert radar.blips[0].name == "b1"
     assert radar.blips[0].is_new is True
+
+
+def test_blip_default_is_new():
+    data = {"name": "b1", "quadrant": "q1", "ring": "r1", "description": "desc"}
+    blip = Blip(**data)
+    assert blip.is_new is False
 
 
 def test_invalid_quadrant():
@@ -56,3 +65,14 @@ def test_invalid_ring():
     }
     with pytest.raises(ValidationError, match="invalid ring 'invalid-r'"):
         Radar(**data)
+
+
+def test_real_radar_json():
+    json_path = project_root() / "tech-radar.json"
+    with json_path.open() as f:
+        data = json.load(f)
+
+    # Should not raise any validation error
+    radar = Radar(**data)
+    assert radar.title == "Sett-and-Hive Radar"
+    assert len(radar.blips) > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,6 +30,18 @@ def test_blip_default_is_new():
     assert blip.is_new is False
 
 
+def test_blip_rejects_unknown_fields():
+    data: dict[str, Any] = {
+        "name": "b1",
+        "quadrant": "q1",
+        "ring": "r1",
+        "is_new": True,
+        "description": "desc",
+    }
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        Blip.model_validate(data)
+
+
 def test_invalid_quadrant():
     data: dict[str, Any] = {
         "title": "Test Radar",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,7 +35,7 @@ def test_blip_rejects_unknown_fields():
         "name": "b1",
         "quadrant": "q1",
         "ring": "r1",
-        "is_new": True,
+        "unknown_field": True,
         "description": "desc",
     }
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+
+from sett_and_hive_radar.models import Radar
+
+
+def test_valid_radar():
+    data = {
+        "title": "Test Radar",
+        "quadrants": ["q1"],
+        "rings": ["r1"],
+        "blips": [
+            {"name": "b1", "quadrant": "q1", "ring": "r1", "isNew": True, "description": "desc"}
+        ],
+    }
+    radar = Radar(**data)
+    assert radar.title == "Test Radar"
+    assert len(radar.blips) == 1
+    assert radar.blips[0].name == "b1"
+    assert radar.blips[0].is_new is True
+
+
+def test_invalid_quadrant():
+    data = {
+        "title": "Test Radar",
+        "quadrants": ["q1"],
+        "rings": ["r1"],
+        "blips": [
+            {
+                "name": "b1",
+                "quadrant": "invalid-q",
+                "ring": "r1",
+                "isNew": True,
+                "description": "desc",
+            }
+        ],
+    }
+    with pytest.raises(ValidationError, match="invalid quadrant 'invalid-q'"):
+        Radar(**data)
+
+
+def test_invalid_ring():
+    data = {
+        "title": "Test Radar",
+        "quadrants": ["q1"],
+        "rings": ["r1"],
+        "blips": [
+            {
+                "name": "b1",
+                "quadrant": "q1",
+                "ring": "invalid-r",
+                "isNew": True,
+                "description": "desc",
+            }
+        ],
+    }
+    with pytest.raises(ValidationError, match="invalid ring 'invalid-r'"):
+        Radar(**data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,6 +80,18 @@ def test_invalid_ring():
         Radar.model_validate(data)
 
 
+def test_radar_rejects_unknown_fields():
+    data: dict[str, Any] = {
+        "title": "Test Radar",
+        "quadrants": ["q1"],
+        "rings": ["r1"],
+        "blips": [],
+        "unexpected": "value",
+    }
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        Radar.model_validate(data)
+
+
 def test_real_radar_json():
     json_path = project_root() / "tech-radar.json"
     with json_path.open() as f:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -8,7 +9,7 @@ from sett_and_hive_radar.paths import project_root
 
 
 def test_valid_radar():
-    data = {
+    data: dict[str, Any] = {
         "title": "Test Radar",
         "quadrants": ["q1"],
         "rings": ["r1"],
@@ -16,7 +17,7 @@ def test_valid_radar():
             {"name": "b1", "quadrant": "q1", "ring": "r1", "isNew": True, "description": "desc"}
         ],
     }
-    radar = Radar(**data)
+    radar = Radar.model_validate(data)
     assert radar.title == "Test Radar"
     assert len(radar.blips) == 1
     assert radar.blips[0].name == "b1"
@@ -24,13 +25,13 @@ def test_valid_radar():
 
 
 def test_blip_default_is_new():
-    data = {"name": "b1", "quadrant": "q1", "ring": "r1", "description": "desc"}
-    blip = Blip(**data)
+    data: dict[str, Any] = {"name": "b1", "quadrant": "q1", "ring": "r1", "description": "desc"}
+    blip = Blip.model_validate(data)
     assert blip.is_new is False
 
 
 def test_invalid_quadrant():
-    data = {
+    data: dict[str, Any] = {
         "title": "Test Radar",
         "quadrants": ["q1"],
         "rings": ["r1"],
@@ -45,11 +46,11 @@ def test_invalid_quadrant():
         ],
     }
     with pytest.raises(ValidationError, match="invalid quadrant 'invalid-q'"):
-        Radar(**data)
+        Radar.model_validate(data)
 
 
 def test_invalid_ring():
-    data = {
+    data: dict[str, Any] = {
         "title": "Test Radar",
         "quadrants": ["q1"],
         "rings": ["r1"],
@@ -64,7 +65,7 @@ def test_invalid_ring():
         ],
     }
     with pytest.raises(ValidationError, match="invalid ring 'invalid-r'"):
-        Radar(**data)
+        Radar.model_validate(data)
 
 
 def test_real_radar_json():
@@ -73,6 +74,6 @@ def test_real_radar_json():
         data = json.load(f)
 
     # Should not raise any validation error
-    radar = Radar(**data)
+    radar = Radar.model_validate(data)
     assert radar.title == "Sett-and-Hive Radar"
     assert len(radar.blips) > 0


### PR DESCRIPTION
Resolves #5. 

### Changes:
- Implemented Pydantic models for `tech-radar.json` validation in `src/sett_and_hive_radar/models.py`.
- Added comprehensive unit tests in `tests/test_models.py` (100% coverage).
- Added ADR 0009 formalizing the use of `cosmic-ray` for mutation testing.
- Implemented `scripts/mutation_test.py` for scoped, transient mutation testing of branch-specific changes.
- Updated `Makefile` and `CONTRIBUTING.md` with new quality workflows.